### PR TITLE
Cleanup data handling

### DIFF
--- a/smtirf/detail/data_dispatch.py
+++ b/smtirf/detail/data_dispatch.py
@@ -5,14 +5,18 @@ from .metadata import TraceMetadata
 
 
 @dataclass(repr=False)
-class DataDispatcher:
+class TimeDispatcherMixin:
     _time: Callable
-    _donor: Callable
-    _acceptor: Callable
 
     @property
     def time(self):
         return self._time()
+
+
+@dataclass(repr=False)
+class FretDispatcher(TimeDispatcherMixin):
+    _donor: Callable
+    _acceptor: Callable
 
     @property
     def donor(self):
@@ -31,7 +35,7 @@ class DataDispatcher:
         return self.acceptor / self.total
 
 
-class TraceDataDispatcher:
+class TraceLoader:
     def __init__(self, file_handle, uid):
         self.file_handle = file_handle
         self.movie_uid, index = uid.split("_")
@@ -48,9 +52,9 @@ class TraceDataDispatcher:
         return TraceMetadata.from_record_dict(record)
 
     def get_data(self, kind):
-        if kind not in ("donor, acceptor"):
-            raise ValueError(f"kind must be 'donor' or 'acceptor; got '{kind}'")
-        return self.file_handle[self.movie_path][f"traces/{kind}_traces"][self.index]
+        if kind not in ("channel_1, channel_2"):
+            raise ValueError(f"kind must be 'channel_1' or 'channel_2; got '{kind}'")
+        return self.file_handle[self.movie_path][f"traces/{kind}"][self.index]
 
     def get_statepath(self, kind):
         if kind not in ("conformation, photophysics"):

--- a/smtirf/detail/data_dispatch.py
+++ b/smtirf/detail/data_dispatch.py
@@ -14,6 +14,10 @@ class SignalDispatcher:
     def time(self):
         return self._time()
 
+    @property
+    def total(self):
+        return self._channel_1() + self._channel_2()
+
 
 @dataclass(repr=False)
 class FretDispatcher(SignalDispatcher):
@@ -26,12 +30,19 @@ class FretDispatcher(SignalDispatcher):
         return self._channel_2()
 
     @property
-    def total(self):
-        return self.donor + self.acceptor
-
-    @property
     def fret(self):
         return self.acceptor / self.total
+
+
+@dataclass(repr=False)
+class TwoColorDispatcher(SignalDispatcher):
+    @property
+    def channel_1(self):
+        return self._channel_1()
+
+    @property
+    def channel_2(self):
+        return self._channel_2()
 
 
 class TraceLoader:
@@ -61,6 +72,10 @@ class TraceLoader:
                 f"kind must be 'conformation' or 'photophysics; got '{kind}'"
             )
         return self.file_handle[self.movie_path][f"statepaths/conformation"][self.index]
+
+    @property
+    def experiment_type(self):
+        return self.file_handle.attrs["experiment_type"]
 
     @property
     def frame_length(self):

--- a/smtirf/detail/data_dispatch.py
+++ b/smtirf/detail/data_dispatch.py
@@ -5,8 +5,10 @@ from .metadata import TraceMetadata
 
 
 @dataclass(repr=False)
-class TimeDispatcherMixin:
+class SignalDispatcher:
     _time: Callable
+    _channel_1: Callable
+    _channel_2: Callable
 
     @property
     def time(self):
@@ -14,17 +16,14 @@ class TimeDispatcherMixin:
 
 
 @dataclass(repr=False)
-class FretDispatcher(TimeDispatcherMixin):
-    _donor: Callable
-    _acceptor: Callable
-
+class FretDispatcher(SignalDispatcher):
     @property
     def donor(self):
-        return self._donor()
+        return self._channel_1()
 
     @property
     def acceptor(self):
-        return self._acceptor()
+        return self._channel_2()
 
     @property
     def total(self):

--- a/smtirf/detail/data_dispatch.py
+++ b/smtirf/detail/data_dispatch.py
@@ -69,3 +69,11 @@ class TraceLoader:
     @property
     def n_frames(self):
         return self.file_handle[self.movie_path].attrs["n_frames"]
+
+    @property
+    def bleedthrough(self):
+        return self.file_handle.attrs["bleedthrough"]
+
+    @property
+    def gamma(self):
+        return self.file_handle.attrs["gamma"]

--- a/smtirf/detail/definitions.py
+++ b/smtirf/detail/definitions.py
@@ -8,12 +8,12 @@ import numpy as np
 
 @dataclass(frozen=True)
 class RawTrace:
-    donor: np.ndarray
-    acceptor: np.ndarray
+    channel_1: np.ndarray
+    channel_2: np.ndarray
 
     @property
     def n_frames(self):
-        return len(self.donor)
+        return len(self.channel_1)
 
 
 @dataclass(frozen=True)
@@ -24,18 +24,18 @@ class Point:
 
 @dataclass
 class Coordinates:
-    """Donor/Acceptor peak coordinates.
+    """Peak coordinates for channel 1 (left) and channel 2 (right).
 
     Attributes
     ----------
-    donor : Point or None
-        Coordinates of the donor spot.
-    acceptor : Point or None
-        Coordinates of the acceptor spot.
+    channel_1 : Point or None
+        Coordinates of the spot in channel 1 (left-side).
+    channel_2 : Point or None
+        Coordinates of the spot in channel 2 (right-side).
     """
 
-    donor: Optional[Point]
-    acceptor: Optional[Point]
+    channel_1: Optional[Point]
+    channel_2: Optional[Point]
 
     @classmethod
     def from_array(cls, arr):
@@ -44,20 +44,20 @@ class Coordinates:
         Parameters
         ----------
         arr: np.ndarray
-            Array of coordinaetes in the form [donor_x, donor_y, acceptor_x, acceptor_y]
+            Array of coordinaetes in the form [ch1_x, ch1_y, ch2_x, ch2_y]
         """
-        donor = Point(*arr[:2])
-        acceptor = Point(*arr[2:])
-        return cls(donor, acceptor)
+        channel_1 = Point(*arr[:2])
+        channel_2 = Point(*arr[2:])
+        return cls(channel_1, channel_2)
 
     @classmethod
     def from_record_dict(cls, record):
-        donor = Point(record["donor_x"], record["donor_y"])
-        acceptor = Point(record["acceptor_x"], record["acceptor_y"])
-        return cls(donor, acceptor)
+        channel_1 = Point(record["ch1_x"], record["ch1_y"])
+        channel_2 = Point(record["ch2_x"], record["ch2_y"])
+        return cls(channel_1, channel_2)
 
     def as_list(self):
-        return [self.donor.x, self.donor.y, self.acceptor.x, self.acceptor.y]
+        return [self.channel_1.x, self.channel_1.y, self.channel_2.x, self.channel_2.y]
 
 
 UNASSIGNED_CONFORMATIONAL_STATE = -1

--- a/smtirf/detail/metadata.py
+++ b/smtirf/detail/metadata.py
@@ -51,14 +51,14 @@ class MovieMetadata:
 TRACE_DTYPE = np.dtype(
     [
         ("trace_id", h5py.string_dtype("utf-8", length=32)),
-        ("donor_x", np.float32),
-        ("donor_y", np.float32),
-        ("acceptor_x", np.float32),
-        ("acceptor_y", np.float32),
+        ("ch1_x", np.float32),
+        ("ch1_y", np.float32),
+        ("ch2_x", np.float32),
+        ("ch2_y", np.float32),
         ("start", np.uint32),
         ("stop", np.uint32),
-        ("donor_offset", np.float32),
-        ("acceptor_offset", np.float32),
+        ("ch1_offset", np.float32),
+        ("ch2_offset", np.float32),
         ("is_selected", bool),
     ]
 )
@@ -72,8 +72,8 @@ class TraceMetadata:
     peak: Optional[Coordinates] = None
     start: Optional[int] = 0
     stop: Optional[int] = None
-    donor_offset: Optional[float] = 0
-    acceptor_offset: Optional[float] = 0
+    ch1_offset: Optional[float] = 0
+    ch2_offset: Optional[float] = 0
     is_selected: Optional[bool] = False
 
     @classmethod
@@ -102,6 +102,12 @@ class TraceMetadata:
         return f"{self.movie_uid}_{index:04d}"
 
     def make_record(self, *, index=None, peak=None):
+        """Return instance attributes as tuple defined by TRACE_DTYPE.
+
+        If self.index and self.peak are None, index and peak arguments must be supplied.
+        This is used for initial data import where HDF5 is not yet written.
+        Essentially acts as a factory to generate metadata records to be written to initial HDF5.
+        """
         # todo: throw if kwargs but already set in instance
 
         trace_uid = [
@@ -116,8 +122,8 @@ class TraceMetadata:
             + [
                 self.start,
                 stop,
-                self.donor_offset,
-                self.acceptor_offset,
+                self.ch1_offset,
+                self.ch2_offset,
                 self.is_selected,
             ]
         )

--- a/smtirf/detail/metadata.py
+++ b/smtirf/detail/metadata.py
@@ -64,7 +64,7 @@ TRACE_DTYPE = np.dtype(
 )
 
 
-@dataclass
+@dataclass(slots=True)
 class TraceMetadata:
     movie_uid: str
     n_frames: int

--- a/smtirf/detail/registry.py
+++ b/smtirf/detail/registry.py
@@ -1,5 +1,6 @@
-from ..traces import Trace
+from ..traces import FretTrace, TwoColorTrace
 
 TRACE_REGISTRY = {
-    "fret": Trace,
+    "fret": FretTrace,
+    "twocolor": TwoColorTrace,
 }

--- a/smtirf/detail/registry.py
+++ b/smtirf/detail/registry.py
@@ -1,0 +1,5 @@
+from ..traces import Trace
+
+TRACE_REGISTRY = {
+    "fret": Trace,
+}

--- a/smtirf/detail/writer.py
+++ b/smtirf/detail/writer.py
@@ -23,7 +23,9 @@ DATASET_OPTS = dict(
 )
 
 
-def write_movie_to_hdf(savename, traces, peaks, metadata, snapshot=None):
+def write_movie_to_hdf(
+    savename, experiment_type, traces, peaks, metadata, snapshot=None
+):
     """Write a movie to HDF5 from raw data import.
 
     To be called from helper functions in smtirf.io.import_dispatch
@@ -32,6 +34,8 @@ def write_movie_to_hdf(savename, traces, peaks, metadata, snapshot=None):
     ----------
     savename: Path
         file path to write HDF5
+    experiment_type: {"fret"}
+        experiment type, controls trace class
     traces: List[RawTrace]
         list of raw trace data
     peaks: List[Coordinates]
@@ -46,6 +50,7 @@ def write_movie_to_hdf(savename, traces, peaks, metadata, snapshot=None):
         hf.attrs["smtirf_version"] = current_version
         hf.attrs["smtrc_version"] = SCHEMA_VERSION
         hf.attrs["date_modified"] = datetime.now().strftime(r"%Y-%m-%d %H:%M:%S")
+        hf.attrs["experiment_type"] = experiment_type
 
         mov_group = _initialize_movie(hf, metadata, snapshot)
         _write_trace_data(mov_group, metadata, traces)

--- a/smtirf/detail/writer.py
+++ b/smtirf/detail/writer.py
@@ -130,11 +130,11 @@ def _write_trace_data(group, movie_metadata, traces):
     traces: List[RawTrace]
         list of raw trace data
     """
-    donor_data = np.vstack([trace.donor for trace in traces])
-    acceptor_data = np.vstack([trace.acceptor for trace in traces])
-    for name, data in zip(("donor", "acceptor"), (donor_data, acceptor_data)):
+    ch1_data = np.vstack([trace.channel_1 for trace in traces])
+    ch2_data = np.vstack([trace.channel_2 for trace in traces])
+    for name, data in zip(("channel_1", "channel_2"), (ch1_data, ch2_data)):
         group.create_dataset(
-            f"traces/{name}_traces",
+            f"traces/{name}",
             data=data,
             dtype="int16",
             chunks=(1, movie_metadata.n_frames),  # row-wise chunking

--- a/smtirf/detail/writer.py
+++ b/smtirf/detail/writer.py
@@ -24,7 +24,14 @@ DATASET_OPTS = dict(
 
 
 def write_movie_to_hdf(
-    savename, experiment_type, traces, peaks, metadata, snapshot=None
+    savename,
+    experiment_type,
+    bleedthrough,
+    gamma,
+    traces,
+    peaks,
+    metadata,
+    snapshot=None,
 ):
     """Write a movie to HDF5 from raw data import.
 
@@ -36,6 +43,10 @@ def write_movie_to_hdf(
         file path to write HDF5
     experiment_type: {"fret"}
         experiment type, controls trace class
+    bleedthrough: float
+        fractional bleedthrough of channel 1 emission to channel 2
+    gamma: float
+        gamma correction
     traces: List[RawTrace]
         list of raw trace data
     peaks: List[Coordinates]
@@ -51,6 +62,8 @@ def write_movie_to_hdf(
         hf.attrs["smtrc_version"] = SCHEMA_VERSION
         hf.attrs["date_modified"] = datetime.now().strftime(r"%Y-%m-%d %H:%M:%S")
         hf.attrs["experiment_type"] = experiment_type
+        hf.attrs["bleedthrough"] = bleedthrough
+        hf.attrs["gamma"] = gamma
 
         mov_group = _initialize_movie(hf, metadata, snapshot)
         _write_trace_data(mov_group, metadata, traces)

--- a/smtirf/experiments.py
+++ b/smtirf/experiments.py
@@ -5,13 +5,14 @@ import h5py
 import smtirf
 
 from .detail.metadata import MovieMetadata
+from .detail.registry import TRACE_REGISTRY
 from .results import Results
-from .traces import Trace
 
 
 class Experiment:
     def __init__(self, filename):
         self._file_handle = h5py.File(Path(filename), "r")
+        self._experiment_type = self._file_handle.attrs["experiment_type"]
 
         self._movies = {
             key: MovieMetadata._from_group(group)
@@ -19,11 +20,12 @@ class Experiment:
         }
 
         # todo: cleanup
+        trace_class = TRACE_REGISTRY[self._experiment_type]
         self._traces = []
         for key, group in self._file_handle["movies"].items():
             trace_ids = group["trace_ids"][:]
             for uid in trace_ids:
-                trace = Trace(self._file_handle, uid.decode("utf-8"))
+                trace = trace_class(self._file_handle, uid.decode("utf-8"))
                 self._traces.append(trace)
 
         # self.comments = comments

--- a/smtirf/io/import_dispatch.py
+++ b/smtirf/io/import_dispatch.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
 from ..detail.metadata import MovieMetadata
+from ..detail.registry import TRACE_REGISTRY
 from ..detail.writer import write_movie_to_hdf
 from . import pma
 
 
 def _validate_experiment_type(experiment_type):
-    if experiment_type not in (defined_experiments := ("fret",)):
+    if experiment_type not in (defined_experiments := tuple(TRACE_REGISTRY.keys())):
         raise ValueError(
             f"experiment type must be in {defined_experiments}; got {experiment_type}"
         )

--- a/smtirf/io/import_dispatch.py
+++ b/smtirf/io/import_dispatch.py
@@ -14,7 +14,9 @@ def _validate_experiment_type(experiment_type):
 
 
 # todo: bleed, gamma
-def load_from_pma(filename, experiment_type="fret", *, savename=None):
+def load_from_pma(
+    filename, experiment_type="fret", *, savename=None, bleedthrough=0.0, gamma=1.0
+):
     _validate_experiment_type(experiment_type)
 
     filename = Path(filename)
@@ -48,4 +50,13 @@ def load_from_pma(filename, experiment_type="fret", *, savename=None):
         log=log,
     )
 
-    write_movie_to_hdf(savename, experiment_type, traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(
+        savename,
+        experiment_type,
+        bleedthrough,
+        gamma,
+        traces,
+        peaks,
+        metadata,
+        snapshot,
+    )

--- a/smtirf/io/import_dispatch.py
+++ b/smtirf/io/import_dispatch.py
@@ -5,8 +5,17 @@ from ..detail.writer import write_movie_to_hdf
 from . import pma
 
 
+def _validate_experiment_type(experiment_type):
+    if experiment_type not in (defined_experiments := ("fret",)):
+        raise ValueError(
+            f"experiment type must be in {defined_experiments}; got {experiment_type}"
+        )
+
+
 # todo: bleed, gamma
-def load_from_pma(filename, *, savename=None):
+def load_from_pma(filename, experiment_type="fret", *, savename=None):
+    _validate_experiment_type(experiment_type)
+
     filename = Path(filename)
     savename = filename.with_suffix(".smtrc") if savename is None else Path(savename)
 
@@ -38,4 +47,4 @@ def load_from_pma(filename, *, savename=None):
         log=log,
     )
 
-    write_movie_to_hdf(savename, traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, experiment_type, traces, peaks, metadata, snapshot)

--- a/smtirf/io/pma.py
+++ b/smtirf/io/pma.py
@@ -24,9 +24,9 @@ def _read_traces(filename):
         )
 
     # split channels, traces as rows
-    donor_traces = data[:, 0::2].T
-    acceptor_traces = data[:, 1::2].T
-    return [RawTrace(d, a) for d, a in zip(donor_traces, acceptor_traces)]
+    ch1_traces = data[:, 0::2].T
+    ch2_traces = data[:, 1::2].T
+    return [RawTrace(d, a) for d, a in zip(ch1_traces, ch2_traces)]
 
 
 def _read_pks(filename):
@@ -34,10 +34,10 @@ def _read_pks(filename):
     Read coordinates from .pks file and return in structured format.
 
     The file format is
-        1      donor_1_x      donor_1_y      donor_1_background (?)
-        2   acceptor_1_x   acceptor_1_y   acceptor_1_background (?)
-        3      donor_2_x      donor_2_y      donor_2_background (?)
-        4   acceptor_2_x   acceptor_2_y   acceptor_2_background (?)
+        1   ch1_1_x   ch1_1_y   ch1_1_background (?)
+        2   ch2_1_x   ch2_1_y   ch2_1_background (?)
+        3   ch1_2_x   ch1_2_y   ch1_2_background (?)
+        4   ch2_2_x   ch2_2_y   ch2_2_background (?)
     """
     with open(filename, "r") as file:
         data = np.loadtxt(file, dtype=float)[:, 1:-1]  # remove first and last columns

--- a/smtirf/traces.py
+++ b/smtirf/traces.py
@@ -29,9 +29,9 @@ class Trace:
         self._loader = TraceLoader(file_handle, uid)
         self._metadata = self._loader.get_metadata()
 
-        # todo: handle this properly
-        self._gamma = 1
-        self._bleed = 0.05
+        # todo: should this be mutable?
+        self._gamma = self._loader.gamma
+        self._bleed = self._loader.bleedthrough
 
         dispatcher_cls = FretDispatcher
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def smtrc_file(tmp_path_factory, mock_data):
 
     write_movie_to_hdf(
         filepath,
+        "fret",
         mock_data.traces,
         mock_data.peaks,
         mock_data.movie_metadata,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,8 @@ def smtrc_file(tmp_path_factory, mock_data):
     write_movie_to_hdf(
         filepath,
         "fret",
+        0.05,
+        1,
         mock_data.traces,
         mock_data.peaks,
         mock_data.movie_metadata,

--- a/tests/test_detail/test_definitions.py
+++ b/tests/test_detail/test_definitions.py
@@ -5,10 +5,10 @@ from smtirf.detail.definitions import Coordinates
 
 def test_coordinates():
     coord = Coordinates.from_array(np.array([1.2, 3.1, 5.1, 3.1]))
-    assert coord.donor.x == 1.2
-    assert coord.donor.y == 3.1
-    assert coord.acceptor.x == 5.1
-    assert coord.acceptor.y == 3.1
+    assert coord.channel_1.x == 1.2
+    assert coord.channel_1.y == 3.1
+    assert coord.channel_2.x == 5.1
+    assert coord.channel_2.y == 3.1
 
 
 # todo: test json_default

--- a/tests/test_detail/test_writer.py
+++ b/tests/test_detail/test_writer.py
@@ -73,16 +73,16 @@ def test_write_movie_to_hdf(
         assert trace_ids[0].decode("utf-8") == f"{metadata.uid}_0000"
         assert trace_ids[1].decode("utf-8") == f"{metadata.uid}_0001"
 
-        donor_data = group["traces/donor_traces"][:]
-        assert donor_data.shape == (2, 5)
+        ch1_data = group["traces/channel_1"][:]
+        assert ch1_data.shape == (2, 5)
         np.testing.assert_equal(
-            donor_data, np.vstack([trace.donor for trace in traces])
+            ch1_data, np.vstack([trace.channel_1 for trace in traces])
         )
 
-        acceptor_data = group["traces/acceptor_traces"][:]
-        assert acceptor_data.shape == (2, 5)
+        ch2_data = group["traces/channel_2"][:]
+        assert ch2_data.shape == (2, 5)
         np.testing.assert_equal(
-            acceptor_data, np.vstack([trace.acceptor for trace in traces])
+            ch2_data, np.vstack([trace.channel_2 for trace in traces])
         )
 
         conf_sp_data = group["statepaths/conformation"][:]

--- a/tests/test_detail/test_writer.py
+++ b/tests/test_detail/test_writer.py
@@ -60,7 +60,7 @@ def test_write_movie_to_hdf(
     metadata = make_movie_metadata(
         log={"key1": "value1", "key2": 50, "key3": timestamp}
     )
-    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", 0.05, 1, traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         assert hf.attrs["date_modified"]
         assert hf.attrs["smtirf_version"] == "0.1.5"
@@ -102,7 +102,7 @@ def test_write_movie_to_hdf_no_snapshot(
 ):
     savename = Path(tmp_path) / "imported_movie_no_snapshot.smtrc"
     metadata = make_movie_metadata(log={"1": 1})
-    write_movie_to_hdf(savename, "fret", traces, peaks, metadata)
+    write_movie_to_hdf(savename, "fret", 0.05, 1, traces, peaks, metadata)
 
     with h5py.File(savename, "r") as hf:
         assert f"movies/movie_{metadata.uid}/snapshot" not in hf
@@ -116,7 +116,7 @@ def test_movie_metadata_written(
     metadata = make_movie_metadata(
         log={"key1": "value1", "key2": 50, "key3": timestamp, "key4": None}
     )
-    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", 0.05, 1, traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         group = hf[f"movies/movie_{metadata.uid}"]
         assert group.attrs["ccd_gain"] == 300
@@ -136,7 +136,7 @@ def test_movie_metadata_written(
     metadata = make_movie_metadata(
         log={"key1": "value1", "key2": 50, "key3": timestamp}, include_data_scaler=False
     )
-    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", 0.05, 1, traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         group = hf[f"movies/movie_{metadata.uid}"]
         assert "data_scaler" not in group.attrs
@@ -144,7 +144,7 @@ def test_movie_metadata_written(
     # no log
     savename = Path(tmp_path) / "imported_movie_no_log.smtrc"
     metadata = make_movie_metadata(log={})
-    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", 0.05, 1, traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         group = hf[f"movies/movie_{metadata.uid}"]
         assert group.attrs["log"] == r"{}"

--- a/tests/test_detail/test_writer.py
+++ b/tests/test_detail/test_writer.py
@@ -60,7 +60,7 @@ def test_write_movie_to_hdf(
     metadata = make_movie_metadata(
         log={"key1": "value1", "key2": 50, "key3": timestamp}
     )
-    write_movie_to_hdf(savename, traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         assert hf.attrs["date_modified"]
         assert hf.attrs["smtirf_version"] == "0.1.5"
@@ -102,7 +102,7 @@ def test_write_movie_to_hdf_no_snapshot(
 ):
     savename = Path(tmp_path) / "imported_movie_no_snapshot.smtrc"
     metadata = make_movie_metadata(log={"1": 1})
-    write_movie_to_hdf(savename, traces, peaks, metadata)
+    write_movie_to_hdf(savename, "fret", traces, peaks, metadata)
 
     with h5py.File(savename, "r") as hf:
         assert f"movies/movie_{metadata.uid}/snapshot" not in hf
@@ -116,7 +116,7 @@ def test_movie_metadata_written(
     metadata = make_movie_metadata(
         log={"key1": "value1", "key2": 50, "key3": timestamp, "key4": None}
     )
-    write_movie_to_hdf(savename, traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         group = hf[f"movies/movie_{metadata.uid}"]
         assert group.attrs["ccd_gain"] == 300
@@ -136,7 +136,7 @@ def test_movie_metadata_written(
     metadata = make_movie_metadata(
         log={"key1": "value1", "key2": 50, "key3": timestamp}, include_data_scaler=False
     )
-    write_movie_to_hdf(savename, traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         group = hf[f"movies/movie_{metadata.uid}"]
         assert "data_scaler" not in group.attrs
@@ -144,7 +144,7 @@ def test_movie_metadata_written(
     # no log
     savename = Path(tmp_path) / "imported_movie_no_log.smtrc"
     metadata = make_movie_metadata(log={})
-    write_movie_to_hdf(savename, traces, peaks, metadata, snapshot)
+    write_movie_to_hdf(savename, "fret", traces, peaks, metadata, snapshot)
     with h5py.File(savename, "r") as hf:
         group = hf[f"movies/movie_{metadata.uid}"]
         assert group.attrs["log"] == r"{}"

--- a/tests/test_io/test_import_dispatch.py
+++ b/tests/test_io/test_import_dispatch.py
@@ -58,4 +58,4 @@ def test_unknown_experiment_type(tmp_path):
 
     with pytest.raises(ValueError) as e:
         load_from_pma(filename, experiment_type="bozo")
-    assert str(e.value) == "experiment type must be in ('fret',); got bozo"
+    assert str(e.value) == "experiment type must be in ('fret', 'twocolor'); got bozo"

--- a/tests/test_io/test_import_dispatch.py
+++ b/tests/test_io/test_import_dispatch.py
@@ -6,6 +6,8 @@ import pytest
 
 from smtirf.io.import_dispatch import load_from_pma
 
+# todo: test happy path!
+
 
 def generate_missing_file_permutations():
     n = [(n_true, 4 - n_true) for n_true in range(1, 4)]
@@ -48,3 +50,12 @@ def test_load_from_pma_missing_files(exists_flags):
 
     n_breaks = msg.count("\n")
     assert n_breaks == 4 - sum(exists_flags)
+
+
+def test_unknown_experiment_type(tmp_path):
+    filename = Path("experiment.traces")
+    savename = Path(tmp_path) / "bad_experiment.smtrc"
+
+    with pytest.raises(ValueError) as e:
+        load_from_pma(filename, experiment_type="bozo")
+    assert str(e.value) == "experiment type must be in ('fret',); got bozo"

--- a/tests/test_io/test_pma.py
+++ b/tests/test_io/test_pma.py
@@ -36,8 +36,8 @@ def test_read_traces():
 
         assert n_traces == n_records // 2
         for k in range(n_traces):
-            np.testing.assert_array_equal(results[k].donor, fake_data[:, k * 2])
-            np.testing.assert_array_equal(results[k].acceptor, fake_data[:, k * 2 + 1])
+            np.testing.assert_array_equal(results[k].channel_1, fake_data[:, k * 2])
+            np.testing.assert_array_equal(results[k].channel_2, fake_data[:, k * 2 + 1])
 
 
 def test_read_pks():
@@ -56,10 +56,10 @@ def test_read_pks():
 
         assert len(results) == 2
         for coord, expected in zip(results, expected_coordinates):
-            assert coord.donor.x == expected[0]
-            assert coord.donor.y == expected[1]
-            assert coord.acceptor.x == expected[2]
-            assert coord.acceptor.y == expected[3]
+            assert coord.channel_1.x == expected[0]
+            assert coord.channel_1.y == expected[1]
+            assert coord.channel_2.x == expected[2]
+            assert coord.channel_2.y == expected[3]
 
 
 def test_read_log():

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -47,7 +47,7 @@ def expected_signals(mock_data):
 
 def test_trace_basic_properties(mock_trace, mock_data):
     trace = mock_trace
-    assert str(trace) == r"Trace	ID=20250824T163642_0000	selected=False"
+    assert str(trace) == r"FretTrace	ID=20250824T163642_0000	selected=False"
     assert len(trace) == mock_data.movie_metadata.n_frames
     assert trace.frame_length == mock_data.movie_metadata.frame_length
 

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -25,13 +25,13 @@ def expected_signals(mock_data):
 
     trace = mock_data.traces[USE_TRACE_INDEX]
 
-    raw = trace.donor
+    raw = trace.channel_1
     offset = 5
     baselined = raw - offset
     corrected = baselined * gamma
     donor = signal(raw, offset, baselined, corrected)
 
-    raw = trace.acceptor
+    raw = trace.channel_2
     offset = 10
     baselined = raw - offset
     corrected = baselined - (donor.baselined * bleed)


### PR DESCRIPTION
- use channel 1/2 in HDF5 file rather than donor/acceptor
- generalize data dispatchers
- include bleedthrough and gamma in legacy data import